### PR TITLE
Create a multi-release jar with Java 9 module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,31 @@
 
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <version>1.0.0.Beta2</version>
+        <executions>
+          <execution>
+            <id>add-module-infos</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <jvmVersion>9</jvmVersion>
+              <module>
+                <moduleInfoSource>
+                  module com.squareup.gifencoder {
+                    requires java.base;
+                    exports com.squareup.gifencoder;
+                  }
+                </moduleInfoSource>
+              </module>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.2</version>


### PR DESCRIPTION
This allows gifencoder to be used as a Java 9 module in Java 9+ projects and maintains Java 7/8 compatibility for non-modular projects.

I know there have been some issues with MR jars in non-Oracle ecosystems like [Websphere](http://www-01.ibm.com/support/docview.wss?uid=swg1PI89708) but I couldn't find any reports of such issues with Android.