### PR TITLE
Make the Image signature addImage public

### DIFF
--- a/src/main/java/com/squareup/gifencoder/GifEncoder.java
+++ b/src/main/java/com/squareup/gifencoder/GifEncoder.java
@@ -84,7 +84,7 @@ public final class GifEncoder {
     outputStream.write(0x3B);
   }
 
-  private synchronized void addImage(Image image, ImageOptions options) throws IOException {
+  public synchronized void addImage(Image image, ImageOptions options) throws IOException {
     if (options.left + image.getWidth() > screenWidth
         || options.top + image.getHeight() > screenHeight) {
       throw new IllegalArgumentException("Image does not fit in screen.");


### PR DESCRIPTION
This was also a small change so I created the PR before asking if the PR would be appreciated - I hope it's not a bother.

My use case is I have bgra byte images I want to use to build a GIF.  Converting to a rgb byte array first adds an additional conversion step to the process and is also lower accuracy then doing the same conversions directly to doubles (which is possible when creating the pixels using `Color`).  And it sidesteps some of the headache of unsigned/signed/int/byte operations.