### PR TITLE
Pad the LZW code table if less than minimum size, alt fix

### DIFF
--- a/src/main/java/com/squareup/gifencoder/LzwEncoder.java
+++ b/src/main/java/com/squareup/gifencoder/LzwEncoder.java
@@ -44,8 +44,11 @@ final class LzwEncoder {
   private int codeSize;
   private List<Integer> indexBuffer = new ArrayList<>();
 
+  /**
+   * @param numColors Padded number of colors, must be a power of 2
+   */
   LzwEncoder(int numColors) {
-    this.numColors = numColors;
+    this.numColors = Math.max(numColors, 4);
     resetCodeTableAndCodeSize();
   }
 


### PR DESCRIPTION
Sorry for the duplicate PRs, I wasn't sure which approach was better and rather than wait for a response I figured I'd try this new approach.

Continuing from #14 , it looks like it's enough to just fix numColors with a minimum.  I also added a docstring indicating that the input value must be a power of 2.