### PR TITLE
Refactor code related to the LZW minimum code size

### DIFF
--- a/src/main/java/com/squareup/gifencoder/GifEncoder.java
+++ b/src/main/java/com/squareup/gifencoder/GifEncoder.java
@@ -106,8 +106,10 @@ public final class GifEncoder {
     ImageDescriptorBlock.write(outputStream, options.left, options.top, image.getWidth(),
         image.getHeight(), true, false, false, getColorTableSizeField(paddedColorCount));
     colorTable.write(outputStream);
-    byte[] lzwData = new LzwEncoder(paddedColorCount).encode(colorIndices);
-    ImageDataBlock.write(outputStream, LzwEncoder.getMinimumCodeSize(paddedColorCount), lzwData);
+
+    LzwEncoder lzwEncoder = new LzwEncoder(paddedColorCount);
+    byte[] lzwData = lzwEncoder.encode(colorIndices);
+    ImageDataBlock.write(outputStream, lzwEncoder.getMinimumCodeSize(), lzwData);
   }
 
   /**

--- a/src/main/java/com/squareup/gifencoder/GifMath.java
+++ b/src/main/java/com/squareup/gifencoder/GifMath.java
@@ -19,6 +19,10 @@ final class GifMath {
   private GifMath() {
   }
 
+  static boolean isPowerOfTwo(int n) {
+    return Integer.bitCount(n) == 1;
+  }
+
   static int roundUpToPowerOfTwo(int n) {
     n--;
     n |= n >> 1;

--- a/src/test/java/com/squareup/gifencoder/LzwEncoderTest.java
+++ b/src/test/java/com/squareup/gifencoder/LzwEncoderTest.java
@@ -1,0 +1,16 @@
+package com.squareup.gifencoder;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LzwEncoderTest {
+  @Test public void testGetMinimumCodeSize() {
+    assertThat(new LzwEncoder(1).getMinimumCodeSize()).isEqualTo(2);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidColorTableSize() {
+    new LzwEncoder(7);
+  }
+}


### PR DESCRIPTION
We were deriving the minimum code size from the number of colors in the LZW code table, which is sort of backwards. The spec defines the "clear" code's value (and implicitly, the number of colors in the LZW code table) based on the minimum code size.

I also made some tweaks to emphasize that the number of colors in the LZW code table may not match the color table size, as @rendaw pointed out in #14. The former quantity is now just a local variable in `defaultCodeTable`, so it's more contained. The latter quantity I renamed to `colorTableSize`.