### PR TITLE
Remove implicitly-included java.base dep in module-info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,6 @@
               <module>
                 <moduleInfoSource>
                   module com.squareup.gifencoder {
-                    requires java.base;
                     exports com.squareup.gifencoder;
                   }
                 </moduleInfoSource>


### PR DESCRIPTION
It looks like `java.base` is an implicit requirement and explicitly requiring it raises an error [here](https://github.com/openjdk/jdk/blob/0e137c973f19bf998f67b6b479b965313a23c2b9/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java#L2146).  

I've confirmed that removing the `requires` allows a minimal test project to compile and run.

The place I encountered this was using `maven-compiler-plugin` 3.8.0 in the `compile` goal:

```
Caused by: java.lang.module.InvalidModuleDescriptorException: Dependence upon java.base already declared
    at jdk.internal.module.ModuleInfo.invalidModuleDescriptor (ModuleInfo.java:1092)
    at jdk.internal.module.ModuleInfo.read (ModuleInfo.java:134)
    at java.lang.module.ModuleDescriptor.read (ModuleDescriptor.java:2508)
    at org.codehaus.plexus.languages.java.jpms.BinaryModuleInfoParser.parse (BinaryModuleInfoParser.java:35)
    at org.codehaus.plexus.languages.java.jpms.AbstractBinaryModuleInfoParser.getModuleDescriptor (AbstractBinaryModuleInfoParser.java:84)
    at org.codehaus.plexus.languages.java.jpms.LocationManager.resolvePaths (LocationManager.java:127)
    at org.apache.maven.plugin.compiler.CompilerMojo.preparePaths (CompilerMojo.java:239)
    at org.apache.maven.plugin.compiler.AbstractCompilerMojo.execute (AbstractCompilerMojo.java:787)
```

I'd like to believe that this was a recent change or due to some unfortunate combination of plugin/jvm/target versions but AFAICT this happens with Java 9+ with target of Java 9+ so I'd need to apologize for the bad PR before.  I'm not sure why I added it originally.